### PR TITLE
Simplify config param defaults

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -16,13 +16,13 @@ class Config
      * @param RuleInterface[] $rules
      */
     public function __construct(
-        private readonly array $sites,
-        private readonly array $rules,
-        private readonly LoggerConfig $loggerConfig,
-        private readonly bool $allowMultipleNotifications,
-        private readonly ?Pushbullet $pushbullet,
-        private readonly ?Telegram $telegram,
-        private readonly ?Ntfy $ntfy,
+        private readonly array $sites = [],
+        private readonly array $rules = [],
+        private readonly LoggerConfig $loggerConfig = new LoggerConfig(),
+        private readonly bool $allowMultipleNotifications = false,
+        private readonly ?Pushbullet $pushbullet = null,
+        private readonly ?Telegram $telegram = null,
+        private readonly ?Ntfy $ntfy = null,
     ) {}
 
     /**

--- a/src/Config/ConfigParser.php
+++ b/src/Config/ConfigParser.php
@@ -55,7 +55,7 @@ class ConfigParser
 
         $rules = $this->getRules($config);
 
-        return new Config($sites, $rules, new LoggerConfig($config), $allowMultipleNotifications, $pushbullet, $telegram, $ntfy);
+        return new Config($sites, $rules, new LoggerConfig($config['logger'] ?? []), $allowMultipleNotifications, $pushbullet, $telegram, $ntfy);
     }
 
     private function getRules(array $config): array

--- a/src/Config/LoggerConfig.php
+++ b/src/Config/LoggerConfig.php
@@ -20,10 +20,9 @@ class LoggerConfig
 
     public function __construct(array $config = [])
     {
-        $loggerConfig = $config['logger'] ?? [];
-        $this->level = Logger::toMonologLevel($loggerConfig['level'] ?? self::DEFAULT_LOG_LEVEL);
-        $this->logToFile = $loggerConfig['file'] ?? false;
-        $this->logFileLocation = $loggerConfig['log_file_location'] ?? self::DEFAULT_LOG_FILE_LOCATION;
+        $this->level = Logger::toMonologLevel($config['level'] ?? self::DEFAULT_LOG_LEVEL);
+        $this->logToFile = $config['log_to_file'] ?? false;
+        $this->logFileLocation = $config['log_file_location'] ?? self::DEFAULT_LOG_FILE_LOCATION;
     }
 
     public function getLogFileLocation(): string

--- a/tests/Config/LoggerConfigTest.php
+++ b/tests/Config/LoggerConfigTest.php
@@ -10,11 +10,23 @@ use PHPUnit\Framework\TestCase;
 
 class LoggerConfigTest extends TestCase
 {
-    public function testParseDefaultValues(): void
+    public function testDefaultValues(): void
     {
         $loggerConfig = new LoggerConfig();
         self::assertEquals(Level::Info, $loggerConfig->getLevel());
         self::assertFalse($loggerConfig->getLogToFile());
         self::assertEquals('./var/log/termin.log', $loggerConfig->getLogFileLocation());
+    }
+
+    public function testOverrideDefaults(): void
+    {
+        $loggerConfig = new LoggerConfig([
+            'level' => 'error',
+            'log_to_file' => true,
+            'log_file_location' => './var/log/random.log',
+        ]);
+        self::assertEquals(Level::Error, $loggerConfig->getLevel());
+        self::assertTrue($loggerConfig->getLogToFile());
+        self::assertEquals('./var/log/random.log', $loggerConfig->getLogFileLocation());
     }
 }

--- a/tests/Config/LoggerConfigTest.php
+++ b/tests/Config/LoggerConfigTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Inverse\Termin\Config;
+
+use Inverse\Termin\Config\LoggerConfig;
+use Monolog\Level;
+use PHPUnit\Framework\TestCase;
+
+class LoggerConfigTest extends TestCase
+{
+    public function testParseDefaultValues(): void
+    {
+        $loggerConfig = new LoggerConfig();
+        self::assertEquals(Level::Info, $loggerConfig->getLevel());
+        self::assertFalse($loggerConfig->getLogToFile());
+        self::assertEquals('./var/log/termin.log', $loggerConfig->getLogFileLocation());
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -5,17 +5,15 @@ declare(strict_types=1);
 namespace Tests\Inverse\Termin;
 
 use Inverse\Termin\Config\Config;
-use Inverse\Termin\Config\LoggerConfig;
 use Inverse\Termin\Container;
 use Inverse\Termin\Termin;
 use PHPUnit\Framework\TestCase;
 
 class ContainerTest extends TestCase
 {
-    public function testGetTermin(): void
+    public function testGetTerminWithDefaultConfig(): void
     {
-        $config = new Config([], [], new LoggerConfig(), false, null, null, null);
-        $container = new Container($config);
+        $container = new Container(new Config());
         self::assertInstanceOf(Termin::class, $container->getTermin());
     }
 }

--- a/tests/Notifier/NotifierFactoryTest.php
+++ b/tests/Notifier/NotifierFactoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Inverse\Termin\Notifier;
 
 use Inverse\Termin\Config\Config;
-use Inverse\Termin\Config\LoggerConfig;
 use Inverse\Termin\Config\Notifier\Ntfy;
 use Inverse\Termin\Config\Notifier\Pushbullet;
 use Inverse\Termin\Config\Notifier\Telegram;
@@ -20,15 +19,7 @@ class NotifierFactoryTest extends TestCase
 {
     public function testEmpty(): void
     {
-        $config = new Config(
-            [],
-            [],
-            new LoggerConfig(),
-            false,
-            null,
-            null,
-            null
-        );
+        $config = new Config();
         $mockMultiNotifier = $this->createMock(MultiNotifier::class);
         $mockMultiNotifier->expects($this->never())->method('addNotifier');
         $notifierFactory = new NotifierFactory($mockMultiNotifier);
@@ -38,15 +29,7 @@ class NotifierFactoryTest extends TestCase
 
     public function testPushbullet(): void
     {
-        $config = new Config(
-            [],
-            [],
-            new LoggerConfig(),
-            false,
-            new Pushbullet('api'),
-            null,
-            null
-        );
+        $config = new Config(pushbullet: new Pushbullet('api'));
 
         $mockMultiNotifier = $this->createMock(MultiNotifier::class);
         $mockMultiNotifier
@@ -61,15 +44,7 @@ class NotifierFactoryTest extends TestCase
 
     public function testTelegram(): void
     {
-        $config = new Config(
-            [],
-            [],
-            new LoggerConfig(),
-            false,
-            null,
-            new Telegram('api', '0'),
-            null
-        );
+        $config = new Config(telegram: new Telegram('api', '0'));
 
         $mockMultiNotifier = $this->createMock(MultiNotifier::class);
         $mockMultiNotifier
@@ -84,15 +59,7 @@ class NotifierFactoryTest extends TestCase
 
     public function testNtfy(): void
     {
-        $config = new Config(
-            [],
-            [],
-            new LoggerConfig(),
-            false,
-            null,
-            null,
-            new Ntfy(Ntfy::DEFAULT_SERVER, 'foobar')
-        );
+        $config = new Config(ntfy: new Ntfy(Ntfy::DEFAULT_SERVER, 'foobar'));
 
         $mockMultiNotifier = $this->createMock(MultiNotifier::class);
         $mockMultiNotifier
@@ -108,13 +75,9 @@ class NotifierFactoryTest extends TestCase
     public function testMultiple(): void
     {
         $config = new Config(
-            [],
-            [],
-            new LoggerConfig(),
-            true,
-            new Pushbullet('yolo'),
-            new Telegram('api', '0'),
-            new Ntfy(Ntfy::DEFAULT_SERVER, 'foobar')
+            pushbullet: new Pushbullet('yolo'),
+            telegram: new Telegram('api', '0'),
+            ntfy: new Ntfy(Ntfy::DEFAULT_SERVER, 'foobar')
         );
 
         $mockMultiNotifier = $this->createMock(MultiNotifier::class);


### PR DESCRIPTION
- Simplify `Config` param defaults
- Add `LoggerConfig` test for defaults and overrides (fixed bug with config parsing file logging)